### PR TITLE
Add user-movie match score endpoint

### DIFF
--- a/apps/api/src/api/main.py
+++ b/apps/api/src/api/main.py
@@ -24,6 +24,7 @@ from api.users import (
     get_profile_stats,
     get_next_movie,
     get_feed,
+    get_user_movie_match,
     get_user_summary,
     recompute_profile,
     upsert_rating,
@@ -142,6 +143,10 @@ class FeedItemResponse(BaseModel):
     distance: float | None
     similarity: float | None
     source: str
+
+
+class UserMovieMatchResponse(BaseModel):
+    score: int | None
 
 
 @app.get("/health")
@@ -313,3 +318,12 @@ def user_feed(user_id: int, k: int = Query(default=20, ge=1, le=100)):
     except UserNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return [FeedItemResponse(**item.__dict__) for item in items]
+
+
+@app.get("/users/{user_id}/movies/{movie_id}/match", response_model=UserMovieMatchResponse)
+def user_movie_match(user_id: int, movie_id: int):
+    try:
+        match = get_user_movie_match(user_id, movie_id)
+    except (UserNotFoundError, MovieNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return UserMovieMatchResponse(**match.__dict__)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -86,6 +86,10 @@ export type FeedItem = {
   source: string;
 };
 
+export type UserMovieMatch = {
+  score: number | null;
+};
+
 export class ApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -128,6 +132,8 @@ export const api = {
   getRatingQueue: (userId: number, k = 20) =>
     request<RatingQueueItem[]>(`/users/${userId}/rating-queue?k=${k}`),
   getNextMovie: (userId: number) => request<NextMovie>(`/users/${userId}/next`),
+  getUserMovieMatch: (userId: number, movieId: number) =>
+    request<UserMovieMatch>(`/users/${userId}/movies/${movieId}/match`),
   rateMovie: (userId: number, movieId: number, rating: number | null, status: string) =>
     request<{ status: string }>(`/users/${userId}/ratings/${movieId}`, {
       method: "PUT",

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -75,13 +75,14 @@ export function useRateMovie() {
   return useMutation({
     mutationFn: ({ userId, movieId, rating, status }: { userId: number; movieId: number; rating: number | null; status: string }) =>
       api.rateMovie(userId, movieId, rating, status),
-    onSuccess: (_, { userId }) => {
+    onSuccess: (_, { userId, movieId }) => {
       queryClient.invalidateQueries({ queryKey: ["ratingQueue", userId] });
       queryClient.invalidateQueries({ queryKey: ["nextMovie", userId] });
       queryClient.invalidateQueries({ queryKey: ["ratings", userId] });
       queryClient.invalidateQueries({ queryKey: ["profileStats", userId] });
       queryClient.invalidateQueries({ queryKey: ["userSummary", userId] });
       queryClient.invalidateQueries({ queryKey: ["feed", userId] });
+      queryClient.invalidateQueries({ queryKey: ["userMovieMatch", userId, movieId] });
     },
   });
 }
@@ -116,6 +117,14 @@ export function useSimilarMovies(movieId: number) {
 
   });
 
+}
+
+export function useUserMovieMatch(userId: number | null, movieId: number | null) {
+  return useQuery({
+    queryKey: ["userMovieMatch", userId, movieId],
+    queryFn: () => api.getUserMovieMatch(userId!, movieId!),
+    enabled: !!userId && !!movieId && !Number.isNaN(movieId),
+  });
 }
 
 

--- a/apps/web/src/pages/MovieDetail.tsx
+++ b/apps/web/src/pages/MovieDetail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useStore } from "../lib/store";
-import { useMovieDetail, useSimilarMovies, useRateMovie, useFeed } from "../lib/hooks";
+import { useMovieDetail, useSimilarMovies, useRateMovie, useUserMovieMatch } from "../lib/hooks";
 import { usePosterHydration } from "../lib/usePosterHydration";
 import { Button } from "../components/ui/button";
 import { Card, CardContent } from "../components/ui/card";
@@ -23,8 +23,7 @@ export function MovieDetail() {
   // Queries
   const { data: detail, isLoading: movieLoading, error: movieError } = useMovieDetail(id);
   const { data: similar, isLoading: similarLoading } = useSimilarMovies(id);
-  // Backend caps k at 100; use max allowed to find match score
-  const { data: feed } = useFeed(userId, 100);
+  const { data: match } = useUserMovieMatch(userId, Number.isNaN(id) ? null : id);
   
   // Mutations
   const rateMovie = useRateMovie();
@@ -62,11 +61,11 @@ export function MovieDetail() {
   }, [detail]);
 
   const similarityScore = useMemo(() => {
-    const sim = feed?.find((item) => item.id === id)?.similarity ?? null;
-    return typeof sim === "number" && !Number.isNaN(sim)
-      ? Math.round(Math.min(100, Math.max(0, sim * 100)))
+    const score = match?.score ?? null;
+    return typeof score === "number" && !Number.isNaN(score)
+      ? Math.round(Math.min(100, Math.max(0, score)))
       : null;
-  }, [feed, id]);
+  }, [match]);
 
   if (movieLoading) {
     return (


### PR DESCRIPTION
## Summary
- add user→movie match endpoint returning a rounded score
- expose user match score hook and API client
- render score badge on movie detail without feed dependency

## Testing
- not run

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a match score system displaying user-movie compatibility as a percentage (0-100) on the movie detail page
  * Added a new API endpoint to retrieve personalized match scores for any user-movie pair
  * Updated the application to use match scores instead of previous similarity metrics for improved compatibility indication

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->